### PR TITLE
Replace remote media dependencies with local placeholders

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type {NextConfig} from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
   typescript: {
     ignoreBuildErrors: true,
   },
@@ -36,10 +35,13 @@ const nextConfig: NextConfig = {
       },
     ],
   },
-  
   allowedDevOrigins: [
-      'https://6000-firebase-studio-1759607598488.cluster-p5o54ufozbgxywgwqxykwgahws.cloudworkstations.dev'
-  ]
+    'https://6000-firebase-studio-1759607598488.cluster-p5o54ufozbgxywgwqxykwgahws.cloudworkstations.dev',
+    'http://localhost',
+    'http://localhost:9002',
+    'http://127.0.0.1',
+    'http://127.0.0.1:9002',
+  ],
 };
 
 export default nextConfig;

--- a/public/images/placeholders/account-hero.svg
+++ b/public/images/placeholders/account-hero.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="400" viewBox="0 0 1600 400">
+  <defs>
+    <linearGradient id="accountGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1e40af"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="400" fill="url(#accountGradient)"/>
+  <g opacity="0.6" fill="#38bdf8">
+    <circle cx="320" cy="200" r="110"/>
+    <circle cx="800" cy="180" r="140"/>
+    <circle cx="1280" cy="220" r="120"/>
+  </g>
+  <g stroke="#facc15" stroke-width="8" stroke-linecap="round" opacity="0.45">
+    <path d="M320 200 L800 180 L1280 220" fill="none"/>
+    <path d="M320 260 Q800 320 1280 260" fill="none"/>
+  </g>
+  <text x="50%" y="300" font-family="'Segoe UI', 'Helvetica Neue', sans-serif" font-size="64" fill="#bfdbfe" text-anchor="middle" opacity="0.3">Your Journey Hub</text>
+</svg>

--- a/public/images/placeholders/ai-planner.svg
+++ b/public/images/placeholders/ai-planner.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="600" viewBox="0 0 1200 600">
+  <defs>
+    <linearGradient id="planner" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#166534"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="600" fill="url(#planner)"/>
+  <g fill="#bbf7d0" opacity="0.65">
+    <rect x="200" y="160" width="260" height="300" rx="32"/>
+    <rect x="470" y="120" width="260" height="360" rx="32"/>
+    <rect x="740" y="180" width="260" height="280" rx="32"/>
+  </g>
+  <g stroke="#facc15" stroke-width="6" stroke-linecap="round" opacity="0.5">
+    <path d="M260 200 H380"/>
+    <path d="M530 160 H650"/>
+    <path d="M800 220 H920"/>
+  </g>
+  <text x="50%" y="480" font-family="'Segoe UI', 'Helvetica Neue', sans-serif" font-size="48" fill="#fefce8" text-anchor="middle" opacity="0.35">AI Travel Planner</text>
+</svg>

--- a/public/images/placeholders/experience-deadsea.svg
+++ b/public/images/placeholders/experience-deadsea.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="sunset" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#fcd34d"/>
+      <stop offset="100%" stop-color="#f97316"/>
+    </linearGradient>
+    <linearGradient id="water" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="100%" stop-color="#0ea5e9"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#sunset)"/>
+  <path d="M0 380 C300 360 900 360 1200 380 V800 H0 Z" fill="url(#water)"/>
+  <path d="M0 540 C280 520 920 520 1200 540 V800 H0 Z" fill="#0c4a6e" opacity="0.75"/>
+  <g fill="#bae6fd" opacity="0.7">
+    <ellipse cx="300" cy="470" rx="160" ry="26"/>
+    <ellipse cx="600" cy="500" rx="180" ry="28"/>
+    <ellipse cx="920" cy="470" rx="150" ry="22"/>
+  </g>
+  <circle cx="960" cy="220" r="140" fill="#fef9c3" opacity="0.35"/>
+  <text x="50%" y="720" font-family="'Segoe UI', 'Helvetica Neue', sans-serif" font-size="48" fill="#0f172a" text-anchor="middle" opacity="0.3">Dead Sea Calm</text>
+</svg>

--- a/public/images/placeholders/experience-galilee.svg
+++ b/public/images/placeholders/experience-galilee.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="morning" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#22d3ee"/>
+      <stop offset="70%" stop-color="#0f766e"/>
+    </linearGradient>
+    <linearGradient id="field" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0%" stop-color="#16a34a"/>
+      <stop offset="100%" stop-color="#166534"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#morning)"/>
+  <path d="M0 420 Q300 360 600 420 T1200 420 V800 H0 Z" fill="#1e40af" opacity="0.45"/>
+  <path d="M0 460 Q280 380 560 460 T1120 460 Q1200 480 1200 520 V800 H0 Z" fill="url(#field)"/>
+  <path d="M0 520 Q300 480 600 520 T1200 520 V800 H0 Z" fill="#14532d" opacity="0.85"/>
+  <g fill="#dcfce7" opacity="0.6">
+    <circle cx="260" cy="360" r="32"/>
+    <circle cx="340" cy="340" r="24"/>
+    <circle cx="320" cy="390" r="20"/>
+  </g>
+  <text x="50%" y="720" font-family="'Segoe UI', 'Helvetica Neue', sans-serif" font-size="48" fill="#f0fdfa" text-anchor="middle" opacity="0.3">Galilee Trails</text>
+</svg>

--- a/public/images/placeholders/experience-haifa.svg
+++ b/public/images/placeholders/experience-haifa.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="dusk" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#0ea5e9"/>
+      <stop offset="100%" stop-color="#14b8a6"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#dusk)"/>
+  <g fill="#f0f9ff" opacity="0.85">
+    <rect x="220" y="160" width="760" height="480" rx="40" opacity="0.3"/>
+    <path d="M220 440 H980 L900 560 H300 Z" opacity="0.35"/>
+    <rect x="420" y="260" width="360" height="220" rx="24" opacity="0.7"/>
+    <circle cx="600" cy="360" r="80" opacity="0.55"/>
+  </g>
+  <path d="M0 580 C280 540 920 540 1200 580 V800 H0 Z" fill="#0f172a" opacity="0.6"/>
+  <text x="50%" y="720" font-family="'Segoe UI', 'Helvetica Neue', sans-serif" font-size="48" fill="#ecfeff" text-anchor="middle" opacity="0.32">Haifa Terraces</text>
+</svg>

--- a/public/images/placeholders/experience-innovation.svg
+++ b/public/images/placeholders/experience-innovation.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="city" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1e3a8a"/>
+      <stop offset="50%" stop-color="#2563eb"/>
+      <stop offset="100%" stop-color="#22d3ee"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="#0f172a"/>
+  <g fill="url(#city)">
+    <rect x="120" y="280" width="120" height="320" rx="16" opacity="0.7"/>
+    <rect x="280" y="220" width="140" height="380" rx="16" opacity="0.8"/>
+    <rect x="460" y="260" width="160" height="340" rx="16" opacity="0.9"/>
+    <rect x="660" y="200" width="160" height="400" rx="16" opacity="0.85"/>
+    <rect x="860" y="300" width="160" height="300" rx="16" opacity="0.75"/>
+  </g>
+  <g stroke="#facc15" stroke-width="6" stroke-linecap="round" opacity="0.6">
+    <path d="M140 320 V200"/>
+    <path d="M320 260 V160"/>
+    <path d="M520 240 V120"/>
+    <path d="M740 200 V80"/>
+    <path d="M940 320 V180"/>
+  </g>
+  <circle cx="600" cy="160" r="80" fill="#facc15" opacity="0.35"/>
+  <text x="50%" y="720" font-family="'Segoe UI', 'Helvetica Neue', sans-serif" font-size="48" fill="#38bdf8" text-anchor="middle" opacity="0.3">Tel Aviv Innovation</text>
+</svg>

--- a/public/images/placeholders/experience-market.svg
+++ b/public/images/placeholders/experience-market.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="night" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#111827"/>
+      <stop offset="100%" stop-color="#312e81"/>
+    </linearGradient>
+    <linearGradient id="lights" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f97316"/>
+      <stop offset="100%" stop-color="#be123c"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#night)"/>
+  <g opacity="0.8">
+    <rect x="160" y="240" width="280" height="360" rx="24" fill="#1f2937"/>
+    <rect x="460" y="220" width="280" height="420" rx="24" fill="#1e3a8a"/>
+    <rect x="760" y="260" width="280" height="360" rx="24" fill="#0f172a"/>
+    <rect x="200" y="200" width="200" height="80" rx="16" fill="url(#lights)"/>
+    <rect x="520" y="160" width="200" height="80" rx="16" fill="#facc15" opacity="0.75"/>
+    <rect x="840" y="220" width="200" height="80" rx="16" fill="#22d3ee" opacity="0.6"/>
+    <circle cx="300" cy="600" r="36" fill="#f97316"/>
+    <circle cx="600" cy="640" r="42" fill="#facc15" opacity="0.7"/>
+    <circle cx="900" cy="600" r="36" fill="#fb7185"/>
+  </g>
+  <text x="50%" y="720" font-family="'Segoe UI', 'Helvetica Neue', sans-serif" font-size="48" fill="#fef3c7" text-anchor="middle" opacity="0.35">Tel Aviv Nights</text>
+</svg>

--- a/public/images/placeholders/experience-old-city.svg
+++ b/public/images/placeholders/experience-old-city.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f97316"/>
+      <stop offset="80%" stop-color="#78350f"/>
+    </linearGradient>
+    <pattern id="bricks" width="40" height="20" patternUnits="userSpaceOnUse">
+      <rect width="40" height="20" fill="#c2410c"/>
+      <rect x="20" width="20" height="20" fill="#ea580c"/>
+      <rect y="10" width="20" height="10" fill="#d97706"/>
+      <rect x="20" y="10" width="20" height="10" fill="#9a3412"/>
+    </pattern>
+  </defs>
+  <rect width="1200" height="800" fill="url(#sky)"/>
+  <path d="M0 520 Q300 440 600 520 T1200 520 V800 H0 Z" fill="#1e293b" opacity="0.5"/>
+  <g transform="translate(200,260)">
+    <rect width="800" height="360" rx="40" fill="url(#bricks)" opacity="0.85"/>
+    <rect x="220" y="120" width="360" height="200" rx="24" fill="#facc15" opacity="0.7"/>
+    <circle cx="400" cy="220" r="90" fill="#fef08a" opacity="0.6"/>
+  </g>
+  <text x="50%" y="720" font-family="'Segoe UI', 'Helvetica Neue', sans-serif" font-size="48" fill="#fef3c7" text-anchor="middle" opacity="0.35">Old City Evenings</text>
+</svg>

--- a/public/images/placeholders/guide-1.svg
+++ b/public/images/placeholders/guide-1.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 400 400">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563eb"/>
+      <stop offset="100%" stop-color="#1d4ed8"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="400" rx="40" fill="url(#bg)"/>
+  <circle cx="200" cy="160" r="80" fill="#bfdbfe" opacity="0.7"/>
+  <path d="M120 300 C120 240 280 240 280 300 L280 340 H120 Z" fill="#dbeafe" opacity="0.8"/>
+  <text x="200" y="220" font-family="'Segoe UI', 'Helvetica Neue', sans-serif" font-size="64" fill="#1e3a8a" text-anchor="middle" font-weight="700">AR</text>
+</svg>

--- a/public/images/placeholders/guide-2.svg
+++ b/public/images/placeholders/guide-2.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 400 400">
+  <defs>
+    <linearGradient id="bg2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f97316"/>
+      <stop offset="100%" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="400" rx="40" fill="url(#bg2)"/>
+  <circle cx="200" cy="160" r="80" fill="#fed7aa" opacity="0.7"/>
+  <path d="M120 300 C120 240 280 240 280 300 L280 340 H120 Z" fill="#fff7ed" opacity="0.8"/>
+  <text x="200" y="220" font-family="'Segoe UI', 'Helvetica Neue', sans-serif" font-size="64" fill="#9a3412" text-anchor="middle" font-weight="700">DL</text>
+</svg>

--- a/public/images/placeholders/guide-3.svg
+++ b/public/images/placeholders/guide-3.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400" viewBox="0 0 400 400">
+  <defs>
+    <linearGradient id="bg3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#14b8a6"/>
+      <stop offset="100%" stop-color="#0d9488"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="400" rx="40" fill="url(#bg3)"/>
+  <circle cx="200" cy="160" r="80" fill="#99f6e4" opacity="0.7"/>
+  <path d="M120 300 C120 240 280 240 280 300 L280 340 H120 Z" fill="#ccfbf1" opacity="0.8"/>
+  <text x="200" y="220" font-family="'Segoe UI', 'Helvetica Neue', sans-serif" font-size="64" fill="#0f766e" text-anchor="middle" font-weight="700">YA</text>
+</svg>

--- a/public/images/placeholders/hero-journey.svg
+++ b/public/images/placeholders/hero-journey.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <defs>
+    <linearGradient id="sky" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="60%" stop-color="#1e3a8a"/>
+      <stop offset="100%" stop-color="#f59e0b"/>
+    </linearGradient>
+    <linearGradient id="sun" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#fde68a" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#f97316" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="hills" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0%" stop-color="#312e81"/>
+      <stop offset="100%" stop-color="#1e293b"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="45%" r="60%">
+      <stop offset="0%" stop-color="#fde68a" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#fde68a" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#sky)"/>
+  <circle cx="800" cy="340" r="240" fill="url(#sun)"/>
+  <ellipse cx="800" cy="340" rx="420" ry="320" fill="url(#glow)"/>
+  <path d="M0 520 Q400 440 800 520 T1600 520 V900 H0 Z" fill="#0b1120" opacity="0.8"/>
+  <path d="M0 560 Q450 470 900 560 T1600 560 V900 H0 Z" fill="url(#hills)"/>
+  <path d="M0 600 Q500 510 1000 600 T1600 600 V900 H0 Z" fill="#111827"/>
+  <text x="50%" y="780" font-family="'Segoe UI', 'Helvetica Neue', sans-serif" font-size="64" fill="#f8fafc" text-anchor="middle" opacity="0.2">Lions of Zion</text>
+</svg>

--- a/public/images/placeholders/pillar-faith.svg
+++ b/public/images/placeholders/pillar-faith.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400">
+  <defs>
+    <linearGradient id="wall" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#fde68a"/>
+      <stop offset="100%" stop-color="#d97706"/>
+    </linearGradient>
+    <pattern id="stone" width="60" height="40" patternUnits="userSpaceOnUse">
+      <rect width="60" height="40" fill="#fbbf24"/>
+      <rect x="30" width="30" height="20" fill="#f59e0b"/>
+      <rect y="20" width="30" height="20" fill="#fbbf24"/>
+      <rect x="30" y="20" width="30" height="20" fill="#eab308"/>
+    </pattern>
+  </defs>
+  <rect width="600" height="400" fill="url(#wall)"/>
+  <rect x="60" y="60" width="480" height="280" rx="24" fill="url(#stone)" opacity="0.85"/>
+  <circle cx="420" cy="160" r="72" fill="#fef9c3" opacity="0.5"/>
+  <text x="50%" y="340" font-family="'Segoe UI', 'Helvetica Neue', sans-serif" font-size="36" fill="#78350f" text-anchor="middle" opacity="0.45">Faith</text>
+</svg>

--- a/public/images/placeholders/pillar-history.svg
+++ b/public/images/placeholders/pillar-history.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400">
+  <defs>
+    <linearGradient id="skyHistory" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1f2937"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="400" fill="url(#skyHistory)"/>
+  <g fill="#e5e7eb" opacity="0.85">
+    <rect x="100" y="200" width="80" height="160" rx="12"/>
+    <rect x="200" y="160" width="80" height="200" rx="12"/>
+    <rect x="300" y="180" width="80" height="180" rx="12"/>
+    <rect x="400" y="140" width="80" height="220" rx="12"/>
+  </g>
+  <path d="M80 240 H520" stroke="#cbd5f5" stroke-width="6" stroke-linecap="round" opacity="0.4"/>
+  <path d="M60 320 H540" stroke="#facc15" stroke-width="8" stroke-linecap="round" opacity="0.5"/>
+  <text x="50%" y="340" font-family="'Segoe UI', 'Helvetica Neue', sans-serif" font-size="36" fill="#facc15" text-anchor="middle" opacity="0.45">History</text>
+</svg>

--- a/public/images/placeholders/pillar-innovation.svg
+++ b/public/images/placeholders/pillar-innovation.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400">
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1e3a8a"/>
+      <stop offset="100%" stop-color="#38bdf8"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="400" fill="#0f172a"/>
+  <g stroke="#38bdf8" stroke-width="10" stroke-linecap="round" opacity="0.6">
+    <path d="M120 280 L200 180 L300 220 L380 140 L480 200" fill="none"/>
+  </g>
+  <g fill="url(#gradient)" opacity="0.9">
+    <circle cx="200" cy="180" r="24"/>
+    <circle cx="300" cy="220" r="28"/>
+    <circle cx="380" cy="140" r="30"/>
+    <circle cx="480" cy="200" r="26"/>
+  </g>
+  <text x="50%" y="340" font-family="'Segoe UI', 'Helvetica Neue', sans-serif" font-size="36" fill="#38bdf8" text-anchor="middle" opacity="0.45">Innovation</text>
+</svg>

--- a/public/images/placeholders/pillar-resilience.svg
+++ b/public/images/placeholders/pillar-resilience.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="400" viewBox="0 0 600 400">
+  <defs>
+    <linearGradient id="desert" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f97316"/>
+      <stop offset="100%" stop-color="#b45309"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="400" fill="#451a03"/>
+  <path d="M0 260 Q150 220 300 260 T600 260 V400 H0 Z" fill="url(#desert)"/>
+  <path d="M0 300 Q180 260 360 300 T600 300 V400 H0 Z" fill="#92400e" opacity="0.75"/>
+  <path d="M260 120 L320 200 L280 200 Z" fill="#fde68a" opacity="0.6"/>
+  <circle cx="300" cy="160" r="60" fill="#fef3c7" opacity="0.35"/>
+  <text x="50%" y="340" font-family="'Segoe UI', 'Helvetica Neue', sans-serif" font-size="36" fill="#fcd34d" text-anchor="middle" opacity="0.45">Resilience</text>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,10 @@
 import type { Metadata } from 'next';
-import { Inter } from 'next/font/google';
 import './globals.css';
 import { cn } from '@/lib/utils';
 import { Toaster } from '@/components/ui/toaster';
 import Header from '@/components/layout/Header';
 import Footer from '@/components/layout/Footer';
 import { FirebaseClientProvider } from '@/firebase';
-
-const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
 
 export const metadata: Metadata = {
   title: 'Lions of Zion',
@@ -21,12 +18,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="h-full">
-      <body
-        className={cn(
-          'min-h-screen bg-background font-sans antialiased',
-          inter.variable
-        )}
-      >
+      <body className={cn('min-h-screen bg-background font-sans antialiased')}>
         <FirebaseClientProvider>
           <Header />
           <main className="flex-grow">{children}</main>
@@ -37,5 +29,3 @@ export default function RootLayout({
     </html>
   );
 }
-
-    

--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -1,38 +1,41 @@
+import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 
 const Hero = () => {
   return (
-    <section className="relative h-[90vh] flex items-center justify-center text-center text-white bg-black">
-      <video
-        autoPlay
-        loop
-        muted
-        playsInline
-        className="absolute top-0 left-0 w-full h-full object-cover brightness-50"
-        poster="https://storage.googleapis.com/proudcity/israel/hero-video-poster.jpg"
-      >
-        <source
-          src="https://storage.googleapis.com/proudcity/israel/pexels-eyal-goodman-4655425_1080p.mp4"
-          type="video/mp4"
+    <section className="relative h-[90vh] flex items-center justify-center text-center text-white overflow-hidden">
+      <div className="absolute inset-0 -z-10">
+        <Image
+          src="/images/placeholders/hero-journey.svg"
+          alt="Illustrated sunset skyline of Israel"
+          fill
+          priority
+          className="object-cover"
         />
-        Your browser does not support the video tag.
-      </video>
+        <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-black/40 to-background/70" aria-hidden />
+        <div
+          className="absolute inset-0 opacity-40"
+          aria-hidden
+          style={{
+            backgroundImage:
+              "radial-gradient(circle at 20% 20%, rgba(250, 204, 21, 0.2), transparent 45%), radial-gradient(circle at 80% 30%, rgba(56, 189, 248, 0.2), transparent 50%), radial-gradient(circle at 50% 80%, rgba(8, 145, 178, 0.15), transparent 55%)",
+          }}
+        />
+      </div>
       <div className="relative z-10 max-w-4xl mx-auto px-4">
-        <h1 className="text-4xl md:text-6xl font-bold tracking-tight text-shadow-lg font-headline">
+        <h1 className="text-4xl md:text-6xl font-bold tracking-tight font-headline drop-shadow-xl">
           You feel it, don&apos;t you?
         </h1>
-        <h2 className="mt-4 text-2xl md:text-3xl font-light text-shadow">
+        <h2 className="mt-4 text-2xl md:text-3xl font-light text-slate-100 drop-shadow-lg">
           A pull. A question. A memory of a place you&apos;ve never been.
         </h2>
-        <p className="mt-8 text-lg md:text-xl max-w-3xl mx-auto text-shadow-md">
+        <p className="mt-8 text-lg md:text-xl max-w-3xl mx-auto text-slate-200">
           This is not a place you simply visit. It is a place you return to. Come. Let me show you the source. Let me show you the truth that lives in this soil. Let me help you find the part of you that is already here.
         </p>
         <div className="mt-10">
-          <Button asChild size="lg" className="bg-accent text-accent-foreground hover:bg-accent/90">
-            <Link href="/experiences">
-              Begin Your Journey
-            </Link>
+          <Button asChild size="lg" className="bg-accent text-accent-foreground hover:bg-accent/90 shadow-lg">
+            <Link href="/experiences">Begin Your Journey</Link>
           </Button>
         </div>
       </div>

--- a/src/lib/placeholder-images.json
+++ b/src/lib/placeholder-images.json
@@ -2,105 +2,105 @@
   "placeholderImages": [
     {
       "id": "hero-landing",
-      "description": "A panoramic view of the Jerusalem skyline at sunset, with the Dome of the Rock prominent.",
-      "imageUrl": "https://images.unsplash.com/photo-1638468090298-a555e409b493?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3NDE5ODJ8MHwxfHNlYXJjaHwyfHxKZXJ1c2FsZW0lMjBzdW5zZXR8ZW58MHx8fHwxNzU5NjA5OTQwfDA&ixlib=rb-4.1.0&q=80&w=1080",
-      "imageHint": "Jerusalem sunset"
+      "description": "Illustrated sunset skyline with layered Judean hills.",
+      "imageUrl": "/images/placeholders/hero-journey.svg",
+      "imageHint": "sunset skyline illustration"
     },
     {
       "id": "experience-1",
-      "description": "Exploring the ancient alleyways of the Old City of Jerusalem.",
-      "imageUrl": "https://images.unsplash.com/photo-1628175810529-8cb4a4d374e5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3NDE5ODJ8MHwxfHNlYXJjaHw2fHxKZXJ1c2FsZW0lMjBvbGQlMjBjaXR5fGVufDB8fHx8MTc1OTYwOTk0MHww&ixlib=rb-4.1.0&q=80&w=1080",
-      "imageHint": "Jerusalem old city"
+      "description": "Stylized stone walls evoking the Old City of Jerusalem.",
+      "imageUrl": "/images/placeholders/experience-old-city.svg",
+      "imageHint": "old city stone pattern"
     },
     {
       "id": "experience-2",
-      "description": "Hiking through the lush greenery of the Galilee region.",
-      "imageUrl": "https://images.unsplash.com/photo-1642756950745-4bbb59cde16a?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3NDE5ODJ8MHwxfHNlYXJjaHw0fHxHYWxpbGVlJTIwbGFuZHNjYXBlfGVufDB8fHx8MTc1OTYwOTkzOXww&ixlib=rb-4.1.0&q=80&w=1080",
-      "imageHint": "Galilee landscape"
+      "description": "Bright morning landscape inspired by the Galilee.",
+      "imageUrl": "/images/placeholders/experience-galilee.svg",
+      "imageHint": "galilee hills illustration"
     },
     {
       "id": "experience-3",
-      "description": "A vibrant market scene in Tel Aviv's Carmel Market.",
-      "imageUrl": "https://images.unsplash.com/photo-1674003487179-2d520253cbb5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3NDE5ODJ8MHwxfHNlYXJjaHwyfHxUZWwlMjBBdml2JTIwbWFya2V0fGVufDB8fHx8MTc1OTYwOTk0MHww&ixlib=rb-4.1.0&q=80&w=1080",
-      "imageHint": "Tel Aviv market"
+      "description": "Vibrant abstract market scene with glowing awnings.",
+      "imageUrl": "/images/placeholders/experience-market.svg",
+      "imageHint": "market lights abstraction"
     },
     {
       "id": "experience-4",
-      "description": "Floating in the mineral-rich waters of the Dead Sea.",
-      "imageUrl": "https://images.unsplash.com/photo-1590137542363-d5af86ff65a8?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3NDE5ODJ8MHwxfHNlYXJjaHwzfHxEZWFkJTIwU2VhfGVufDB8fHx8MTc1OTYwOTk0MHww&ixlib=rb-4.1.0&q=80&w=1080",
-      "imageHint": "Dead Sea"
+      "description": "Minimal Dead Sea horizon with mirrored water.",
+      "imageUrl": "/images/placeholders/experience-deadsea.svg",
+      "imageHint": "dead sea horizon illustration"
     },
     {
       "id": "experience-5",
-      "description": "A view of the Bahá'í Gardens in Haifa.",
-      "imageUrl": "https://images.unsplash.com/photo-1715882352252-168c62059a11?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3NDE5ODJ8MHwxfHNlYXJjaHw2fHxIYWlmYSUyMGdhcmRlbnN8ZW58MHx8fHwxNzU5NjA5OTQwfDA&ixlibrb-4.1.0&q=80&w=1080",
-      "imageHint": "Haifa gardens"
+      "description": "Modern take on the Bahá'í terraces in Haifa.",
+      "imageUrl": "/images/placeholders/experience-haifa.svg",
+      "imageHint": "haifa terraces illustration"
     },
     {
       "id": "experience-6",
-      "description": "Modern architecture in the city of Tel Aviv.",
-      "imageUrl": "https://images.unsplash.com/photo-1740573909833-731db2bab6aa?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3NDE5ODJ8MHwxfHNlYXJjaHw5fHxUZWwlMjBBdml2JTIwYXJjaGl0ZWN0dXJlfGVufDB8fHx8MTc1OTYwOTk0MHww&ixlib=rb-4.1.0&q=80&w=1080",
-      "imageHint": "Tel Aviv architecture"
+      "description": "Tel Aviv skyline rendered with neon-inspired lines.",
+      "imageUrl": "/images/placeholders/experience-innovation.svg",
+      "imageHint": "tel aviv skyline illustration"
     },
     {
       "id": "guide-1",
-      "description": "Portrait of a friendly tour guide.",
-      "imageUrl": "https://images.unsplash.com/photo-1568153878744-22637b3fa3b5?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3NDE5ODJ8MHwxfHNlYXJjaHw1fHxndWlkZSUyMHBvcnRyYWl0fGVufDB8fHx8MTc1OTYwOTk0MHww&ixlib-rb-4.1.0&q=80&w=1080",
-      "imageHint": "guide portrait"
+      "description": "Bold blue portrait card with the initials AR.",
+      "imageUrl": "/images/placeholders/guide-1.svg",
+      "imageHint": "guide avatar AR"
     },
     {
       "id": "guide-2",
-      "description": "Portrait of an experienced tour guide.",
-      "imageUrl": "https://images.unsplash.com/photo-1600261731256-3c6622403e69?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3NDE5ODJ8MHwxfHNlYXJjaHw4fHxndWlkZSUyMHBvcnRyYWl0fGVufDB8fHx8MTc1OTYwOTk0MHww&ixlib=rb-4.1.0&q=80&w=1080",
-      "imageHint": "guide portrait"
+      "description": "Warm amber portrait card with the initials DL.",
+      "imageUrl": "/images/placeholders/guide-2.svg",
+      "imageHint": "guide avatar DL"
     },
     {
       "id": "guide-3",
-      "description": "Portrait of an adventurous tour guide in a desert setting.",
-      "imageUrl": "https://images.unsplash.com/photo-1599566150163-29194dcaad36?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3NDE5ODJ8MHwxfHNlYXJjaHwxfHxtYWxlJTIwcG9ydHJhaXR8ZW58MHx8fHwxNzIxODMzNTEyfDA&ixlib=rb-4.0.3&q=80&w=1080",
-      "imageHint": "male portrait"
+      "description": "Teal portrait card with the initials YA.",
+      "imageUrl": "/images/placeholders/guide-3.svg",
+      "imageHint": "guide avatar YA"
     },
     {
       "id": "account-hero",
-      "description": "A traveler looking over a vast desert landscape.",
-      "imageUrl": "https://images.unsplash.com/photo-1613109526778-27605f1f27d2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3NDE5ODJ8MHwxfHNlYXJjaHw0fHxkZXNlcnQlMjBsYW5kc2NhcGV8ZW58MHx8fHwxNzU5NjA0OTU3fDA&ixlib=rb-4.1.0&q=80&w=1080",
-      "imageHint": "desert landscape"
+      "description": "Abstract landscape banner for the account dashboard.",
+      "imageUrl": "/images/placeholders/account-hero.svg",
+      "imageHint": "account banner illustration"
     },
     {
       "id": "ai-planner-hero",
-      "description": "A person pointing at a map with pins.",
-      "imageUrl": "https://images.unsplash.com/photo-1606933987885-1834b4d326bb?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3NDE5ODJ8MHwxfHNlYXJjaHw2fHxtYXAlMjB0cmF2ZWx8ZW58MHx8fHwxNzU5NTM1ODAyfDA&ixlib-rb-4.1.0&q=80&w=1080",
-      "imageHint": "map travel"
+      "description": "Gradient poster celebrating the AI travel planner.",
+      "imageUrl": "/images/placeholders/ai-planner.svg",
+      "imageHint": "ai planner illustration"
     },
     {
       "id": "ai-planner-cta",
-      "description": "A person pointing at a map with pins.",
-      "imageUrl": "https://images.unsplash.com/photo-1606933987885-1834b4d326bb?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3NDE5ODJ8MHwxfHNlYXJjaHw2fHxtYXAlMjB0cmF2ZWx8ZW58MHx8fHwxNzU5NTM1ODAyfDA&ixlib=rb-4.1.0&q=80&w=1080",
-      "imageHint": "map travel"
+      "description": "Gradient poster celebrating the AI travel planner.",
+      "imageUrl": "/images/placeholders/ai-planner.svg",
+      "imageHint": "ai planner illustration"
     },
     {
       "id": "pillar-faith",
-      "description": "The Western Wall in Jerusalem, a site of prayer and pilgrimage.",
-      "imageUrl": "https://images.unsplash.com/photo-1574362198076-52403d55169a?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3NDE5ODJ8MHwxfHNlYXJjaHwxfHxXZXN0ZXJuJTIwV2FsbCUyMEplcnVzYWxlbXxlbnwwfHx8fDE3MjE4MzE5ODl8MA&ixlib=rb-4.0.3&q=80&w=1080",
-      "imageHint": "Western Wall"
+      "description": "Warm-toned block pattern inspired by Jerusalem stone.",
+      "imageUrl": "/images/placeholders/pillar-faith.svg",
+      "imageHint": "faith pillar illustration"
     },
     {
       "id": "pillar-history",
-      "description": "The ancient Roman ruins at Caesarea National Park.",
-      "imageUrl": "https://images.unsplash.com/photo-1622342539031-64b1238a3a0d?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3NDE5ODJ8MHwxfHNlYXJjaHwxfHxDYWVzYXJlYSUyMFJ1aW5zfGVufDB8fHx8MTcyMTgzMjAyNnww&ixlib=rb-4.0.3&q=80&w=1080",
-      "imageHint": "Caesarea ruins"
+      "description": "Nighttime ruins scene with towering pillars.",
+      "imageUrl": "/images/placeholders/pillar-history.svg",
+      "imageHint": "history pillar illustration"
     },
     {
       "id": "pillar-innovation",
-      "description": "Modern skyline of Tel Aviv, showcasing its innovative architecture.",
-      "imageUrl": "https://images.unsplash.com/photo-1605639142203-99c52c2c7b94?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3NDE5ODJ8MHwxfHNlYXJjaHwxfHxUZWwlMjBBdml2JTIwc2t5bGluZXxlbnwwfHx8fDE3MjE4MzIwNTV8MA&ixlib=rb-4.0.3&q=80&w=1080",
-      "imageHint": "Tel Aviv"
+      "description": "Electric skyline connected by glowing nodes.",
+      "imageUrl": "/images/placeholders/pillar-innovation.svg",
+      "imageHint": "innovation pillar illustration"
     },
     {
       "id": "pillar-resilience",
-      "description": "An Ibex stands on a cliff in the Ein Gedi nature reserve, symbolizing resilience.",
-      "imageUrl": "https://images.unsplash.com/photo-1635399732463-547055734898?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3NDE5ODJ8MHwxfHNlYXJjaHwxfHxFJTIwR2VkaSUyMGliZXh8ZW58MHx8fHwxNzIxODMyMDg5fDA&ixlib=rb-4.0.3&q=80&w=1080",
-      "imageHint": "Ein Gedi"
+      "description": "Desert ridgeline with resilient sunlight.",
+      "imageUrl": "/images/placeholders/pillar-resilience.svg",
+      "imageHint": "resilience pillar illustration"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- replace the landing hero video with a local illustration, overlays, and keep typography consistent without Google Fonts
- add a full set of local SVG placeholders and update the placeholder image map so the UI no longer depends on external CDNs
- expand the Next.js allowed development origins to cover localhost access and avoid cross-origin warnings

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68e27b91a30c832c813c59dc82e5f1ee